### PR TITLE
chore(release) 2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,12 @@ services:
 
 env:
   global:
-    - LUAROCKS=2.4.3
-    - OPENSSL=1.0.2n
+    - LUAROCKS=3.1.3
+    - OPENSSL=1.1.1c
     - CASSANDRA_BASE=2.2.12
     - CASSANDRA_LATEST=3.9
-    - OPENRESTY_BASE=1.13.6.2
-    - OPENRESTY_LATEST=1.13.6.2
+    - OPENRESTY_BASE=1.15.8.1
+    - OPENRESTY_LATEST=1.15.8.1
     - DOWNLOAD_CACHE=$HOME/download-cache
     - INSTALL_CACHE=$HOME/install-cache
     - BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6"

--- a/kong-plugin-session-2.0.0-1.rockspec
+++ b/kong-plugin-session-2.0.0-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 dependencies = {
   "lua >= 5.1",
-  "lua-resty-session == 2.23",
+  "lua-resty-session == 2.24",
   --"kong >= 1.2.0",
 }
 

--- a/kong-plugin-session-2.1.0-1.rockspec
+++ b/kong-plugin-session-2.1.0-1.rockspec
@@ -1,12 +1,12 @@
 package = "kong-plugin-session"
 
-version = "2.0.0-1"
+version = "2.1.0-1"
 
 supported_platforms = {"linux", "macosx"}
 
 source = {
   url = "git://github.com/Kong/kong-plugin-session",
-  tag = "2.0.0"
+  tag = "2.1.0"
 }
 
 description = {

--- a/kong/plugins/session/handler.lua
+++ b/kong/plugins/session/handler.lua
@@ -1,8 +1,9 @@
-local BasePlugin = require "kong.plugins.base_plugin"
 local access = require "kong.plugins.session.access"
 local session = require "kong.plugins.session.session"
 
+
 local kong = kong
+
 
 local KongSessionHandler = {
   PRIORITY = 1900,

--- a/kong/plugins/session/handler.lua
+++ b/kong/plugins/session/handler.lua
@@ -7,7 +7,7 @@ local kong = kong
 
 local KongSessionHandler = {
   PRIORITY = 1900,
-  VERSION = "2.0.0",
+  VERSION = "2.1.0",
 }
 
 

--- a/kong/plugins/session/migrations/000_base_session.lua
+++ b/kong/plugins/session/migrations/000_base_session.lua
@@ -13,9 +13,9 @@ return {
 
       DO $$
       BEGIN
-        IF (SELECT to_regclass('session_sessions_expires_idx')) IS NULL THEN
-          CREATE INDEX session_sessions_expires_idx ON sessions (expires);
-        END IF;
+        CREATE INDEX IF NOT EXISTS "session_sessions_expires_idx" ON "sessions" ("expires");
+      EXCEPTION WHEN UNDEFINED_COLUMN THEN
+        -- Do nothing, accept existing state
       END$$;
     ]],
   },

--- a/kong/plugins/session/session.lua
+++ b/kong/plugins/session/session.lua
@@ -1,5 +1,9 @@
+local storage = require "kong.plugins.session.storage.kong"
 local session = require "resty.session"
+
+
 local kong = kong
+local ipairs = ipairs
 
 
 local _M = {}
@@ -37,7 +41,7 @@ function _M.open_session(conf)
     -- after "cookie_discard" period.
     opts.strategy = "regenerate"
     s = session.new(opts)
-    s.storage = require("kong.plugins.session.storage.kong").new(s)
+    s.storage = storage.new(s)
     s:open()
   else
     opts.storage = conf.storage

--- a/kong/plugins/session/session.lua
+++ b/kong/plugins/session/session.lua
@@ -94,24 +94,24 @@ function _M.logout(conf)
         break
       end
     end
+
     if logout then
       logout = false
 
       local logout_query_arg = conf.logout_query_arg
       if logout_query_arg then
-        local uri_args = kong.request.get_query()
-        if uri_args[logout_query_arg] then
+        if kong.request.get_query_arg(logout_query_arg) then
           logout = true
         end
       end
 
       if logout then
         kong.log.debug("logout by query argument")
+
       else
         local logout_post_arg = conf.logout_post_arg
         if logout_post_arg then
-          ngx.req.read_body()
-          local post_args = ngx.req.get_post_args()
+          local post_args = kong.request.get_body()
           if post_args[logout_post_arg] then
             logout = true
           end

--- a/kong/plugins/session/session.lua
+++ b/kong/plugins/session/session.lua
@@ -1,6 +1,7 @@
 local session = require "resty.session"
 local kong = kong
 
+
 local _M = {}
 
 


### PR DESCRIPTION
### Summary

Contains a resty session bump and some small cleanups.

- style(session) add one extra line feed
- style(session) localize global access
- chore(migrations) small change to make migration a bit more re-entrant
- refactor(session) use kong pdk to read the post args for logout
- chore(handler) remove unused base plugin require
- chore(deps) bump resty session to 2.24
- chore(travis) bump versions to make it work with next branch of kong
- chore(release) 2.1.0