### PR TITLE
feat(groups) add authenticated_groups to storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,17 +190,25 @@ host, but can be overridden.
 
 ## Session Data Storage
 
-The session data can be stored in the cookie itself (encrypted) `storage=cookie`, or 
-inside [Kong](#-kong-storage-adapter). The session data stores two context
+The session data can be stored in the cookie itself (encrypted) `storage=cookie`
+, or inside [Kong](#-kong-storage-adapter). The session data these context 
 variables:
 
 ```
 ngx.ctx.authenticated_consumer.id
 ngx.ctx.authenticated_credential.id
+ngx.ctx.authenticated_groups
 ```
 
-The plugin also sets a `ngx.ctx.authenticated_session` for communication between the
-`access` and `header_filter` phases in the plugin.
+The plugin also sets a `ngx.ctx.authenticated_session` for communication between
+ the `access` and `header_filter` phases in the plugin.
+ 
+### Groups
+
+Authenticated groups are stored on `ngx.ctx.authenticated_groups` from other 
+authentication plugins and the session plugin will store them in the data of 
+the current session. Since the session plugin runs before authentication 
+plugins, it will also set `authenticated_groups` associated headers.
 
 ## 🦍 Kong Storage Adapter
 

--- a/kong/plugins/session/access.lua
+++ b/kong/plugins/session/access.lua
@@ -14,7 +14,7 @@ local function load_consumer(consumer_id)
 end
 
 
-local function set_consumer(consumer, credential_id)
+local function authenticate(consumer, credential_id, groups)
   local set_header = kong.service.request.set_header
   local clear_header = kong.service.request.clear_header
 
@@ -29,6 +29,12 @@ local function set_consumer(consumer, credential_id)
     set_header(constants.HEADERS.CONSUMER_USERNAME, consumer.username)
   else
     clear_header(constants.HEADERS.CONSUMER_USERNAME)
+  end
+
+  if groups then
+    set_header(constants.HEADERS.AUTHENTICATED_GROUPS, table.concat(groups, ", "))
+  else
+    clear_header(constants.HEADERS.AUTHENTICATED_GROUPS)
   end
 
   if credential_id then
@@ -59,7 +65,7 @@ function _M.execute(conf)
   end
 
 
-  local cid, credential = session.retrieve_session_data(s)
+  local cid, credential, groups = session.retrieve_session_data(s)
 
   local consumer_cache_key = kong.db.consumers:cache_key(cid)
   local consumer, err = kong.cache:get(consumer_cache_key, nil,
@@ -78,7 +84,7 @@ function _M.execute(conf)
 
   s:start()
 
-  set_consumer(consumer, credential)
+  authenticate(consumer, credential, groups)
 
   kong.ctx.shared.authenticated_session = s
 end

--- a/kong/plugins/session/access.lua
+++ b/kong/plugins/session/access.lua
@@ -33,6 +33,7 @@ local function authenticate(consumer, credential_id, groups)
 
   if groups then
     set_header(constants.HEADERS.AUTHENTICATED_GROUPS, table.concat(groups, ", "))
+    ngx.ctx.authenticated_groups = groups
   else
     clear_header(constants.HEADERS.AUTHENTICATED_GROUPS)
   end

--- a/kong/plugins/session/handler.lua
+++ b/kong/plugins/session/handler.lua
@@ -11,6 +11,25 @@ local KongSessionHandler = {
 }
 
 
+local function get_authenticated_groups()
+  local authenticated_groups = ngx.ctx.authenticated_groups
+  if authenticated_groups == nil then
+    return nil
+  end
+
+  assert(type(authenticated_groups) == "table",
+         "invalid authenticated_groups, a table was expected")
+
+  local groups = {}
+  for i = 1, #authenticated_groups do
+    groups[i] = authenticated_groups[i]
+    groups[authenticated_groups[i]] = authenticated_groups[i]
+  end
+
+  return groups
+end
+
+
 function KongSessionHandler:header_filter(conf)
   local credential = kong.client.get_credential()
   local consumer = kong.client.get_consumer()
@@ -24,7 +43,7 @@ function KongSessionHandler:header_filter(conf)
   local credential_id = credential.id
   local consumer_id = consumer and consumer.id
   local s = kong.ctx.shared.authenticated_session
-  local groups = kong.client.get_authenticated_groups()
+  local groups = get_authenticated_groups()
 
   -- if session exists and the data in the session matches the ctx then
   -- don't worry about saving the session data or sending cookie

--- a/kong/plugins/session/handler.lua
+++ b/kong/plugins/session/handler.lua
@@ -24,6 +24,7 @@ function KongSessionHandler:header_filter(conf)
   local credential_id = credential.id
   local consumer_id = consumer and consumer.id
   local s = kong.ctx.shared.authenticated_session
+  local groups = kong.client.get_authenticated_groups()
 
   -- if session exists and the data in the session matches the ctx then
   -- don't worry about saving the session data or sending cookie
@@ -39,7 +40,8 @@ function KongSessionHandler:header_filter(conf)
   -- create new session and save the data / send the Set-Cookie header
   if consumer_id then
     s = s or session.open_session(conf)
-    session.store_session_data(s, consumer_id, credential_id or consumer_id)
+    session.store_session_data(s, consumer_id, credential_id or consumer_id,
+                               groups)
     s:save()
   end
 end

--- a/kong/plugins/session/handler.lua
+++ b/kong/plugins/session/handler.lua
@@ -20,13 +20,7 @@ local function get_authenticated_groups()
   assert(type(authenticated_groups) == "table",
          "invalid authenticated_groups, a table was expected")
 
-  local groups = {}
-  for i = 1, #authenticated_groups do
-    groups[i] = authenticated_groups[i]
-    groups[authenticated_groups[i]] = authenticated_groups[i]
-  end
-
-  return groups
+  return authenticated_groups
 end
 
 

--- a/kong/plugins/session/session.lua
+++ b/kong/plugins/session/session.lua
@@ -55,12 +55,12 @@ end
 
 --- Gets consumer id and credential id from the session data
 -- @param s - the session
--- @returns consumer_id, credential_id
+-- @returns consumer_id, credential_id, groups
 function _M.retrieve_session_data(s)
-  if not s then return nil, nil end
+  if not s then return nil, nil, nil end
 
   if s and not s.data then
-    return nil, nil
+    return nil, nil, nil
   end
 
   return s.data[1], s.data[2], s.data[3]
@@ -71,7 +71,7 @@ end
 -- @param s - the session
 -- @param consumer - the consumer id
 -- @param credential - the credential id or potentially just the consumer id
--- @param groups - table of authenticated_groups e.g. ["1" = "group1", "group1"]
+-- @param groups - table of authenticated_groups e.g. { "group1" }
 function _M.store_session_data(s, consumer_id, credential_id, groups)
   if not s then
     return

--- a/kong/plugins/session/session.lua
+++ b/kong/plugins/session/session.lua
@@ -79,13 +79,7 @@ function _M.store_session_data(s, consumer_id, credential_id, groups)
 
   s.data[1] = consumer_id
   s.data[2] = credential_id
-
-  if groups then
-    -- ensure serialized table is set to array so data is not stored as json
-    -- with mixed type (e.g. object _and_ array).
-    setmetatable(groups, cjson.array_mt)
-    s.data[3] = groups
-  end
+  s.data[3] = groups
 
 end
 


### PR DESCRIPTION
Session storage to now add ctx.authenticated_groups which gives it
similar functionality to the "acl" plugin. This means that users can
assign groups to their consumers via some authentication plugin
(LDAP, OIDC, etc.) and session will maintain and store groups in
session data.

Fixes INTF-1934