### PR TITLE
chore(*) release 2.4.0 (includes lua-resty-session 3.3 bump)

### DIFF
--- a/kong-plugin-session-2.4.0-1.rockspec
+++ b/kong-plugin-session-2.4.0-1.rockspec
@@ -1,12 +1,12 @@
 package = "kong-plugin-session"
 
-version = "2.3.0-1"
+version = "2.4.0-1"
 
 supported_platforms = {"linux", "macosx"}
 
 source = {
   url = "git://github.com/Kong/kong-plugin-session",
-  tag = "2.3.0"
+  tag = "2.4.0"
 }
 
 description = {
@@ -17,7 +17,7 @@ description = {
 
 dependencies = {
   "lua >= 5.1",
-  "lua-resty-session == 3.1",
+  "lua-resty-session == 3.3",
   --"kong >= 1.2.0",
 }
 

--- a/kong/plugins/session/handler.lua
+++ b/kong/plugins/session/handler.lua
@@ -4,7 +4,7 @@ local header_filter = require "kong.plugins.session.header_filter"
 
 local KongSessionHandler = {
   PRIORITY = 1900,
-  VERSION  = "2.3.0",
+  VERSION  = "2.4.0",
 }
 
 


### PR DESCRIPTION
### Summary

Release `2.4.0` that also bumps `lua-resty-session` dependency to `3.3`.