### PR TITLE
chore(*) release 2.4.1 

### DIFF
--- a/kong-plugin-session-2.4.0-1.rockspec
+++ b/kong-plugin-session-2.4.0-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 dependencies = {
   "lua >= 5.1",
-  "lua-resty-session == 3.3",
+  "lua-resty-session == 3.5",
   --"kong >= 1.2.0",
 }
 

--- a/kong/plugins/session/handler.lua
+++ b/kong/plugins/session/handler.lua
@@ -4,7 +4,7 @@ local header_filter = require "kong.plugins.session.header_filter"
 
 local KongSessionHandler = {
   PRIORITY = 1900,
-  VERSION  = "2.4.0",
+  VERSION  = "2.4.1",
 }
 
 


### PR DESCRIPTION
### Summary

- bump lua-resty-session from 3.3 to 3.5