### PR TITLE
chore(*) release 2.4.2

### DIFF
--- a/kong-plugin-session-2.4.2-1.rockspec
+++ b/kong-plugin-session-2.4.2-1.rockspec
@@ -1,12 +1,12 @@
 package = "kong-plugin-session"
 
-version = "2.4.1-1"
+version = "2.4.2-1"
 
 supported_platforms = {"linux", "macosx"}
 
 source = {
   url = "git://github.com/Kong/kong-plugin-session",
-  tag = "2.4.1"
+  tag = "2.4.2"
 }
 
 description = {

--- a/kong-plugin-session-2.4.2-1.rockspec
+++ b/kong-plugin-session-2.4.2-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 dependencies = {
   "lua >= 5.1",
-  "lua-resty-session == 3.5",
+  "lua-resty-session == 3.6",
   --"kong >= 1.2.0",
 }
 

--- a/kong/plugins/session/handler.lua
+++ b/kong/plugins/session/handler.lua
@@ -4,7 +4,7 @@ local header_filter = require "kong.plugins.session.header_filter"
 
 local KongSessionHandler = {
   PRIORITY = 1900,
-  VERSION  = "2.4.1",
+  VERSION  = "2.4.2",
 }
 
 


### PR DESCRIPTION
### Summary

Bump `lua-resty-session` dependency from `3.5` to `3.6`.