### PR TITLE
enable using `session_id` in admin API

### DIFF
--- a/kong/plugins/session/daos.lua
+++ b/kong/plugins/session/daos.lua
@@ -3,6 +3,7 @@ local typedefs = require "kong.db.schema.typedefs"
 return {
   sessions = {
     primary_key = { "id" },
+    endpoint_key = "session_id",
     name = "sessions",
     cache_key = { "session_id" },
     ttl = true,


### PR DESCRIPTION
Set `endpoint_key` to allow session to be retrieved via the `session_id` in the admin API