### PR TITLE
chore(*) release 2.4.4

### DIFF
--- a/kong-plugin-session-2.4.3-1.rockspec
+++ b/kong-plugin-session-2.4.3-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 dependencies = {
   "lua >= 5.1",
-  "lua-resty-session == 3.6",
+  "lua-resty-session == 3.8",
   --"kong >= 1.2.0",
 }
 

--- a/kong-plugin-session-2.4.4-1.rockspec
+++ b/kong-plugin-session-2.4.4-1.rockspec
@@ -1,12 +1,12 @@
 package = "kong-plugin-session"
 
-version = "2.4.3-1"
+version = "2.4.4-1"
 
 supported_platforms = {"linux", "macosx"}
 
 source = {
   url = "git://github.com/Kong/kong-plugin-session",
-  tag = "2.4.3"
+  tag = "2.4.4"
 }
 
 description = {

--- a/kong/plugins/session/handler.lua
+++ b/kong/plugins/session/handler.lua
@@ -4,7 +4,7 @@ local header_filter = require "kong.plugins.session.header_filter"
 
 local KongSessionHandler = {
   PRIORITY = 1900,
-  VERSION  = "2.4.3",
+  VERSION  = "2.4.4",
 }
 
 


### PR DESCRIPTION
### Summary

- chore(deps) bump lua-resty-session from 3.6 to 3.8 
- chore(*) release 2.4.4