### PR TITLE
tests(*) make proxy client usage more robust

### DIFF
--- a/kong-plugin-session-2.4.5-1.rockspec
+++ b/kong-plugin-session-2.4.5-1.rockspec
@@ -1,12 +1,12 @@
 package = "kong-plugin-session"
 
-version = "2.4.4-1"
+version = "2.4.5-1"
 
 supported_platforms = {"linux", "macosx"}
 
 source = {
   url = "git://github.com/Kong/kong-plugin-session",
-  tag = "2.4.4"
+  tag = "2.4.5"
 }
 
 description = {

--- a/kong/plugins/session/handler.lua
+++ b/kong/plugins/session/handler.lua
@@ -4,7 +4,7 @@ local header_filter = require "kong.plugins.session.header_filter"
 
 local KongSessionHandler = {
   PRIORITY = 1900,
-  VERSION  = "2.4.4",
+  VERSION  = "2.4.5",
 }
 
 


### PR DESCRIPTION
### Summary

It seems like the proxy client when used multiple times for subsequent request may be a bit flaky at times. Especially if the previous request errored, it may have closed the connectiont too, thus subsequent request failing on that same client.

This commit grabs a new client for each request.

This should be bullet-proofed on Kong repo, but this fixes the issues here for now.